### PR TITLE
Close parent after grace ends

### DIFF
--- a/lib/throng.js
+++ b/lib/throng.js
@@ -51,6 +51,7 @@ module.exports = function(startFn, options) {
     for (var id in cluster.workers) {
       cluster.workers[id].kill();
     }
+    process.exit();
   }
 };
 


### PR DESCRIPTION
Only added one line, exit the parent process after the forceKill loop instead of having to kill-9 it.