### PR TITLE
Don't need all of lodash, just a small subset (i.e. `defaults`)

### DIFF
--- a/lib/throng.js
+++ b/lib/throng.js
@@ -1,7 +1,7 @@
 var os = require('os');
 var cluster = require('cluster');
 var EventEmitter = require('events').EventEmitter;
-var defaults = require('lodash').defaults;
+var defaults = require('lodash.defaults');
 
 var DEFAULT_OPTIONS = {
   workers: os.cpus().length,

--- a/package.json
+++ b/package.json
@@ -24,6 +24,6 @@
     "mocha": "2.4.5"
   },
   "dependencies": {
-    "lodash": "4.3.0"
+    "lodash.defaults": "^4.0.1"
   }
 }


### PR DESCRIPTION
less bloat