### PR TITLE
Promote use of LTS node version (4.x currently)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: node_js
 node_js:
-  - "0.10"
+  - "4"
   - "stable"

--- a/package.json
+++ b/package.json
@@ -15,13 +15,13 @@
     "test": "mocha"
   },
   "engines": {
-    "node": ">= 0.10.x"
+    "node": "4"
   },
   "author": "Hunter Loftis <hunter@hunterloftis.com>",
   "license": "MIT",
   "devDependencies": {
-    "chai": "3.5.0",
-    "mocha": "2.4.5"
+    "chai": "^3.5.0",
+    "mocha": "^2.4.5"
   },
   "dependencies": {
     "lodash": "4.3.0"


### PR DESCRIPTION
_Note that, unless the user has set the `engine-strict` config flag, this field is advisory only_