### PR TITLE
Added: worker env vars and masterFn() promise

### DIFF
--- a/lib/throng.js
+++ b/lib/throng.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const Promise = require('bluebird');
 const cluster = require('cluster');
 const EventEmitter = require('events').EventEmitter;
 const defaults = require('lodash.defaults');
@@ -21,6 +22,7 @@ module.exports = function throng(options, startFunction) {
   if (typeof startFn !== 'function') {
     throw new Error('Start function required');
   }
+
   if (cluster.isWorker) {
     return startFn(cluster.worker.id);
   }
@@ -32,8 +34,9 @@ module.exports = function throng(options, startFunction) {
   let runUntil = Date.now() + opts.lifetime;
 
   listen();
-  masterFn();
-  fork();
+  Promise.resolve(masterFn())
+    .then(fork)
+    .catch(err => console.error(err));
 
   function listen() {
     cluster.on('exit', revive);
@@ -45,7 +48,7 @@ module.exports = function throng(options, startFunction) {
 
   function fork() {
     for (var i = 0; i < opts.workers; i++) {
-      cluster.fork();
+      cluster.fork(options.env);
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "mocha": "^2.4.5"
   },
   "dependencies": {
+    "bluebird": "^3.4.1",
     "lodash.defaults": "^4.0.1"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -69,10 +69,22 @@ Handling signals (for cleanup on a kill signal, for instance).
 ```js
 throng({
   workers: 4,       // Number of workers (cpu count)
+
   lifetime: 10000,  // ms to keep cluster alive (Infinity)
+
   grace: 4000,      // ms grace period after worker SIGTERM (5000)
+
   master: masterFn, // Function to call when starting the master process
-  start: startFn    // Function to call when starting the worker processes
+                    // master is a Promise and will resolve before `start`
+                    // function is called. Removing the possibility of a race
+                    // condition.
+
+  start: startFn,   // Function to call when starting the worker processes
+
+  env: {            // Additional env vars to place on worker processes
+    myenv1:'envVal',// that don't already exist on the master process
+    myenv2:'envVal2'
+  } 
 });
 ```
 
@@ -84,7 +96,12 @@ const throng = require('throng');
 throng({
   workers: 4,
   master: startMaster,
-  start: startWorker
+  start: startWorker,
+  env: {
+    NODE_ENV: 'dev',
+    MY_OTHER_ENV_VAR: 17,
+    THIS_VAL_TOO: 'value'
+  }
 });
 
 // This will only be called once


### PR DESCRIPTION
When using throng I noticed two things I wanted to help improve:

- Child processes start before the master process `masterFn()` is finished. In my case this is undesired. I am asynchronously retrieving environment variables that Ithen put on the master process. I expect the child processes to inherit these variables from the parent process, but they don't because the child process start before the async variables are retrieved and set.

**Fix:** masterFn is wrapped in promise, and resolved before `cluster.fork`. No unintended residual affects result.

- I noticed while going over the docs for process, cluster, and child_process, that [child processes can optionally be handed an object](https://nodejs.org/api/cluster.html#cluster_cluster_fork_env) whose property/value pairs will be placed on the child process (in addition to it's existing process). I don't need this in my case because I am inheriting from the parent process, but I saw it as a nice to have and an easy fix so I added it as an option.

**Fix:** Added optional `env` object to options. Pass it into `cluster.fork()`.

Documentation added for new features.