### PR TITLE
Enhanced signal support

### DIFF
--- a/lib/throng.js
+++ b/lib/throng.js
@@ -39,6 +39,7 @@ module.exports = function throng(options, startFunction) {
     cluster.on('exit', revive);
     emitter.once('shutdown', shutdown);
     var shutdownSignals = ['SIGINT', 'SIGTERM'];
+    if (opts.extraShutdownSignal) shutdownSignals.push(opts.extraShutdownSignal);
     shutdownSignals.forEach((signal) => {
       process.once(signal, () => emitter.emit('shutdown', signal));
     });

--- a/lib/throng.js
+++ b/lib/throng.js
@@ -38,9 +38,10 @@ module.exports = function throng(options, startFunction) {
   function listen() {
     cluster.on('exit', revive);
     emitter.once('shutdown', shutdown);
-    process
-      .on('SIGINT', proxySignal)
-      .on('SIGTERM', proxySignal);
+    var shutdownSignals = ['SIGINT', 'SIGTERM'];
+    shutdownSignals.forEach((signal) => {
+      process.once(signal, () => emitter.emit('shutdown', signal));
+    });
   }
 
   function fork() {
@@ -49,16 +50,20 @@ module.exports = function throng(options, startFunction) {
     }
   }
 
-  function proxySignal() {
-    emitter.emit('shutdown');
-  }
-
-  function shutdown() {
+  function shutdown(signal) {
     running = false;
     for (var id in cluster.workers) {
       cluster.workers[id].process.kill();
     }
+
+    // Unref'ing the timer ensures that the only thing keeping the master alive
+    // (as far as this module knows) are the connections to the child processes.
+    // When they disconnect (either because they exit voluntarily or because
+    // we disconnect them with `Worker#kill`), we'll receive the 'exit' event.
+    // Kill with the shutdown signal to respect signal exit codes: 
+    // https://nodejs.org/api/process.html#process_exit_codes
     setTimeout(forceKill, opts.grace).unref();
+    process.on('exit', () => process.kill(process.pid, signal));
   }
 
   function revive(worker, code, signal) {

--- a/readme.md
+++ b/readme.md
@@ -68,11 +68,13 @@ Handling signals (for cleanup on a kill signal, for instance).
 
 ```js
 throng({
-  workers: 4,       // Number of workers (cpu count)
-  lifetime: 10000,  // ms to keep cluster alive (Infinity)
-  grace: 4000,      // ms grace period after worker SIGTERM (5000)
-  master: masterFn, // Function to call when starting the master process
-  start: startFn    // Function to call when starting the worker processes
+  workers: 4,                     // Number of workers (cpu count)
+  lifetime: 10000,                // ms to keep cluster alive (Infinity)
+  grace: 4000,                    // ms grace period after worker SIGTERM (5000)
+  master: masterFn,               // Function to call when starting the master process
+  start: startFn,                 // Function to call when starting the worker processes
+  extraShutdownSignal: 'SIGUSR2'  // Extra signal (beyond SIGINT & SIGTERM) in response
+                                  // to which to shut down the cluster
 });
 ```
 

--- a/test/fixtures/sigusr2.js
+++ b/test/fixtures/sigusr2.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const throng = require('../../lib/throng');
+
+throng({
+  workers: 3,
+  lifetime: 500,
+  start: () => {
+    console.log('worker');
+
+    process.on('SIGTERM', function() {
+      console.log('exiting');
+      process.exit();
+    });
+  },
+  extraShutdownSignal: 'SIGUSR2'
+});

--- a/test/throng.test.js
+++ b/test/throng.test.js
@@ -15,6 +15,7 @@ const masterCmd = path.join(__dirname, 'fixtures', 'master');
 const gracefulCmd = path.join(__dirname, 'fixtures', 'graceful');
 const killCmd = path.join(__dirname, 'fixtures', 'kill');
 const infiniteCmd = path.join(__dirname, 'fixtures', 'infinite');
+const sigusr2Cmd = path.join(__dirname, 'fixtures', 'sigusr2');
 
 describe('throng()', function() {
 
@@ -170,6 +171,20 @@ describe('throng()', function() {
       });
       it('exits with SIGINT', function() {
         assert.equal(this.signal, 'SIGINT');
+      });
+    });
+
+    describe('with custom signal handling', function() {
+      before(function(done) {
+        var child = run(sigusr2Cmd, this, done);
+        setTimeout(function() { child.kill('SIGUSR2'); }, 750);
+      });
+      it('allows the workers to shut down', function() {
+        var exits = this.stdout.match(/exiting/g).length;
+        assert.equal(exits, 3);
+      });
+      it('exits with SIGUSR2', function() {
+        assert.equal(this.signal, 'SIGUSR2');
       });
     });
 


### PR DESCRIPTION
This PR enables `throng` to observe a shutdown signal beyond `SIGINT` and `SIGTERM`, for instance `SIGUSR2`. Two use cases that support the various changes in this PR:
1. The process monitor we use for local development, [`nodemon`](https://github.com/remy/nodemon), uses `SIGUSR2` to restart the process. If the process traps the signal to enact some graceful shutdown, `nodemon` expects the process to [re-kill itself with `SIGUSR2`](https://github.com/remy/nodemon#controlling-shutdown-of-your-script)—nodemon detects the corresponding exit code to resume control.
2. We run our applications on AWS Elastic Beanstalk. We add support for graceful shutdown to EB simply by sending `SIGUSR2` to all Node processes before EB enacts deploys, makes configuration changes, etc; and then waiting for a period of time for the processes to exit.

Why `SIGUSR2` and not one of the default signals (`SIGTERM` or `SIGINT`)? In the case of `nodemon`, because it's not customizable; in the case of EB, because we send the signal to all processes and we don't want the worker processes to exit before the master has begun the shutdown process.

The EB use case is the more compelling since we don't really need to use clustering in local development. But, now `throng` supports that too. The only `nodemon`-specific change is having `throng` exit with the code corresponding to the shutdown signal. If you feel we shouldn't change that behavior I can take it out, but it seems like good practice for the process to respect the signal exit codes as documented by Node in “Signal Exits” [here](https://nodejs.org/api/process.html#process_exit_codes).
