### PR TITLE
Support the 'beforeExit' event in the master process

### DIFF
--- a/example-complex.js
+++ b/example-complex.js
@@ -9,6 +9,14 @@ throng({
 // This will only be called once
 function startMaster() {
   console.log(`Started master`);
+
+  process.on('beforeExit', () => {
+    // `throng.shutdownSignal` will be `undefined` if the cluster exited without
+    // being killed e.g. if the workers exited by themselves and `lifetime` is 0.
+    console.log(`Master exiting in response to ${throng.shutdownSignal}...`);
+    // Making async calls will keep the master alive.
+    console.log('(master cleanup would happen here)');
+  });
 }
 
 // This will be called four times

--- a/lib/throng.js
+++ b/lib/throng.js
@@ -38,9 +38,10 @@ module.exports = function throng(options, startFunction) {
   function listen() {
     cluster.on('exit', revive);
     emitter.once('shutdown', shutdown);
-    process
-      .on('SIGINT', proxySignal)
-      .on('SIGTERM', proxySignal);
+    var shutdownSignals = ['SIGINT', 'SIGTERM'];
+    shutdownSignals.forEach((signal) => {
+      process.on(signal, () => emitter.emit('shutdown', signal));
+    });
   }
 
   function fork() {
@@ -49,12 +50,9 @@ module.exports = function throng(options, startFunction) {
     }
   }
 
-  function proxySignal() {
-    emitter.emit('shutdown');
-  }
-
-  function shutdown() {
+  function shutdown(signal) {
     running = false;
+    module.exports.shutdownSignal = signal;
     for (var id in cluster.workers) {
       cluster.workers[id].process.kill();
     }
@@ -69,6 +67,5 @@ module.exports = function throng(options, startFunction) {
     for (var id in cluster.workers) {
       cluster.workers[id].kill();
     }
-    process.exit();
   }
 };

--- a/readme.md
+++ b/readme.md
@@ -90,6 +90,14 @@ throng({
 // This will only be called once
 function startMaster() {
   console.log('Started master');
+
+  process.on('beforeExit', () => {
+    // `throng.shutdownSignal` will be `undefined` if the cluster exited without
+    // being killed e.g. if the workers exited by themselves and `lifetime` is 0.
+    console.log(`Master exiting in response to ${throng.shutdownSignal}...`);
+    // Making async calls will keep the master alive.
+    console.log('(master cleanup would happen here)');
+  });
 }
 
 // This will be called four times
@@ -114,6 +122,8 @@ Started worker 4
 
 $ killall node
 
+Master exiting in response to SIGTERM...
+(master cleanup would happen here)
 Worker 3 exiting...
 Worker 4 exiting...
 (cleanup would happen here)

--- a/test/fixtures/beforeExit-graceful.js
+++ b/test/fixtures/beforeExit-graceful.js
@@ -1,0 +1,22 @@
+'use strict';
+
+const throng = require('../../lib/throng');
+
+throng({
+  workers: 2,
+  master: () => {
+    console.log('master');
+    
+    process.on('beforeExit', () => {
+      console.log(`Master exiting in response to ${throng.shutdownSignal}...`);
+    });
+  },
+  start: () => {
+    console.log('worker');
+    
+    process.on('SIGTERM', function() {
+      console.log('exiting');
+      process.exit();
+    });
+  }
+});

--- a/test/fixtures/beforeExit-kill.js
+++ b/test/fixtures/beforeExit-kill.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const throng = require('../../lib/throng');
+
+throng({
+  lifetime: 0,
+  workers: 2,
+  grace: 250,
+  master: () => {
+    console.log('master');
+    
+    process.on('beforeExit', () => {
+      console.log(`Master exiting in response to ${throng.shutdownSignal}...`);
+    });
+  },
+  start: () => {
+    console.log('ah ha ha ha');
+
+    process.on('SIGTERM', function() {
+      console.log('stayin alive');
+    });
+  }
+});

--- a/test/fixtures/beforeExit.js
+++ b/test/fixtures/beforeExit.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const throng = require('../../lib/throng');
+
+throng({
+  lifetime: 0,
+  workers: 2,
+  master: () => {
+    console.log('master');
+
+    process.on('beforeExit', () => {
+      console.log(`Master exiting in response to ${throng.shutdownSignal}...`);
+    });
+  },
+  start: () => {
+    console.log('worker');
+    process.exit();
+  }
+});

--- a/test/throng.test.js
+++ b/test/throng.test.js
@@ -15,6 +15,9 @@ const masterCmd = path.join(__dirname, 'fixtures', 'master');
 const gracefulCmd = path.join(__dirname, 'fixtures', 'graceful');
 const killCmd = path.join(__dirname, 'fixtures', 'kill');
 const infiniteCmd = path.join(__dirname, 'fixtures', 'infinite');
+const beforeExitCmd = path.join(__dirname, 'fixtures', 'beforeExit');
+const beforeExitGracefulCmd = path.join(__dirname, 'fixtures', 'beforeExit-graceful');
+const beforeExitKillCmd = path.join(__dirname, 'fixtures', 'beforeExit-kill');
 
 describe('throng()', function() {
 
@@ -124,6 +127,39 @@ describe('throng()', function() {
       });
       it('kills the workers after 250ms', function() {
         assert.closeTo(this.endTime - this.startTime, 1000, 100);
+      });
+    });
+
+  });
+
+  describe('`beforeExit` handler', function() {
+
+    describe('with 3 workers that immediately exit', function() {
+      before(function(done) {
+        run(beforeExitCmd, this, done);
+      });
+      it('the `beforeExit` handler is invoked', function() {
+        assert.notEqual(this.stdout.indexOf('Master exiting in response to undefined'), -1);
+      });
+    });
+
+    describe('with 3 workers that exit gracefully', function() {
+      before(function(done) {
+        var child = run(beforeExitGracefulCmd, this, done);
+        setTimeout(function() { child.kill(); }, 750);
+      });
+      it('the `beforeExit` handler is invoked', function() {
+        assert.notEqual(this.stdout.indexOf('Master exiting in response to SIGTERM'), -1);
+      });
+    });
+
+    describe('with 3 workers that fail to exit', function() {
+      before(function(done) {
+        var child = run(beforeExitKillCmd, this, done);
+        setTimeout(function() { child.kill(); }, 750);
+      });
+      it('the `beforeExit` handler is invoked', function() {
+        assert.notEqual(this.stdout.indexOf('Master exiting in response to SIGTERM'), -1);
       });
     });
 


### PR DESCRIPTION
So that the master can do cleanup before exiting.

The 'beforeExit' event is a useful way of exposing this both because it requires
no additional configuration of `throng` and because the master process will
automatically be kept alive if the user makes asynchronous calls from within
the 'beforeExit' event.

In order for the 'beforeExit' event to be emitted when it is necessary to
forceably disconnect the worker processes, we must not explicitly terminate
the process i.e. by calling `process.exit`. But this is not necessary since
disconnecting the workers will cause the master process to exit anyway.

The cluster’s shutdown signal is exposed for the 'beforeExit' handler to
examine if desired.
