### PR TITLE
Shil/forward worker environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
+sudo: false
+
 language: node_js
 node_js:
-  - "4.0.0"
-  - "stable"
+  - "8.9.3"
+  - "8"
+  - "node"

--- a/example-complex.js
+++ b/example-complex.js
@@ -9,6 +9,14 @@ throng({
 // This will only be called once
 function startMaster() {
   console.log(`Started master`);
+
+  process.on('beforeExit', () => {
+    // `throng.shutdownSignal` will be `undefined` if the cluster exited without
+    // being killed e.g. if the workers exited by themselves and `lifetime` is 0.
+    console.log(`Master exiting in response to ${throng.shutdownSignal}...`);
+    // Making async calls will keep the master alive.
+    console.log('(master cleanup would happen here)');
+  });
 }
 
 // This will be called four times

--- a/lib/throng.js
+++ b/lib/throng.js
@@ -15,8 +15,8 @@ const NOOP = () => {};
 
 module.exports = function throng(options, startFunction) {
   options = options || {};
-  let startFn = options.start || startFunction || options;
-  let masterFn = options.master || NOOP;
+  const startFn = options.start || startFunction || options;
+  const masterFn = options.master || NOOP;
 
   if (typeof startFn !== 'function') {
     throw new Error('Start function required');
@@ -25,11 +25,12 @@ module.exports = function throng(options, startFunction) {
     return startFn(cluster.worker.id);
   }
 
-  let opts = isNaN(options) ?
+  const opts = isNaN(options) ?
     defaults(options, DEFAULT_OPTIONS) : defaults({ workers: options }, DEFAULT_OPTIONS);
-  let emitter = new EventEmitter();
+  const emitter = new EventEmitter();
+  const runUntil = Date.now() + opts.lifetime;
+
   let running = true;
-  let runUntil = Date.now() + opts.lifetime;
 
   listen();
   masterFn();
@@ -38,7 +39,7 @@ module.exports = function throng(options, startFunction) {
   function listen() {
     cluster.on('disconnect', revive);
     emitter.once('shutdown', shutdown);
-    var shutdownSignals = ['SIGINT', 'SIGTERM'];
+    const shutdownSignals = ['SIGINT', 'SIGTERM'];
     if (opts.extraShutdownSignal) shutdownSignals.push(opts.extraShutdownSignal);
     shutdownSignals.forEach((signal) => {
       process.once(signal, () => emitter.emit('shutdown', signal));
@@ -46,7 +47,7 @@ module.exports = function throng(options, startFunction) {
   }
 
   function fork() {
-    for (var i = 0; i < opts.workers; i++) {
+    for (let i = 0; i < opts.workers; i++) {
       cluster.fork();
     }
   }
@@ -54,7 +55,7 @@ module.exports = function throng(options, startFunction) {
   function shutdown(signal) {
     running = false;
     module.exports.shutdownSignal = signal;
-    for (var id in cluster.workers) {
+    for (const id in cluster.workers) {
       cluster.workers[id].process.kill();
     }
 
@@ -74,7 +75,7 @@ module.exports = function throng(options, startFunction) {
   }
 
   function forceKill() {
-    for (var id in cluster.workers) {
+    for (const id in cluster.workers) {
       forceKillWorker(cluster.workers[id]);
     }
   }

--- a/lib/throng.js
+++ b/lib/throng.js
@@ -36,7 +36,7 @@ module.exports = function throng(options, startFunction) {
 
   listen();
   masterFn();
-  fork();
+  fork(opts.env);
 
   function listen() {
     cluster.on('disconnect', revive);
@@ -49,9 +49,13 @@ module.exports = function throng(options, startFunction) {
     });
   }
 
-  function fork() {
+  /**
+   * See {@link https://nodejs.org/docs/latest-v10.x/api/cluster.html#cluster_cluster_fork_env}
+   * @param {Object} env Key/value pairs to add to worker process environment.
+   */
+  function fork(env) {
     for (let i = 0; i < opts.workers; i++) {
-      cluster.fork();
+      cluster.fork(env);
     }
   }
 

--- a/lib/throng.js
+++ b/lib/throng.js
@@ -39,6 +39,7 @@ module.exports = function throng(options, startFunction) {
     cluster.on('exit', revive);
     emitter.once('shutdown', shutdown);
     var shutdownSignals = ['SIGINT', 'SIGTERM'];
+    if (opts.extraShutdownSignal) shutdownSignals.push(opts.extraShutdownSignal);
     shutdownSignals.forEach((signal) => {
       process.once(signal, () => emitter.emit('shutdown', signal));
     });

--- a/lib/throng.js
+++ b/lib/throng.js
@@ -36,7 +36,7 @@ module.exports = function throng(options, startFunction) {
   fork();
 
   function listen() {
-    cluster.on('exit', revive);
+    cluster.on('disconnect', revive);
     emitter.once('shutdown', shutdown);
     var shutdownSignals = ['SIGINT', 'SIGTERM'];
     if (opts.extraShutdownSignal) shutdownSignals.push(opts.extraShutdownSignal);
@@ -69,12 +69,17 @@ module.exports = function throng(options, startFunction) {
   }
 
   function revive(worker, code, signal) {
+    setTimeout(forceKillWorker, opts.grace, worker).unref();
     if (running && Date.now() < runUntil) cluster.fork();
   }
 
   function forceKill() {
     for (var id in cluster.workers) {
-      cluster.workers[id].kill();
+      forceKillWorker(cluster.workers[id]);
     }
+  }
+
+  function forceKillWorker(worker) {
+    if (!worker.isDead()) worker.kill('SIGKILL');
   }
 };

--- a/lib/throng.js
+++ b/lib/throng.js
@@ -28,6 +28,7 @@ module.exports = function throng(options, startFunction) {
   const opts = isNaN(options) ?
     defaults(options, DEFAULT_OPTIONS) : defaults({ workers: options }, DEFAULT_OPTIONS);
   const emitter = new EventEmitter();
+  const externEmitter = new EventEmitter();
   const runUntil = Date.now() + opts.lifetime;
 
   let running = true;
@@ -38,6 +39,8 @@ module.exports = function throng(options, startFunction) {
 
   function listen() {
     cluster.on('disconnect', revive);
+    cluster.on('disconnect', (worker) => externEmitter.emit('disconnect', worker.pid));
+    cluster.on('exit', (worker) => externEmitter.emit('exit', worker.pid));
     emitter.once('shutdown', shutdown);
     const shutdownSignals = ['SIGINT', 'SIGTERM'];
     if (opts.extraShutdownSignal) shutdownSignals.push(opts.extraShutdownSignal);
@@ -83,4 +86,6 @@ module.exports = function throng(options, startFunction) {
   function forceKillWorker(worker) {
     if (!worker.isDead()) worker.kill('SIGKILL');
   }
+
+  return externEmitter;
 };

--- a/lib/throng.js
+++ b/lib/throng.js
@@ -62,7 +62,7 @@ module.exports = function throng(options, startFunction) {
     // (as far as this module knows) are the connections to the child processes.
     // When they disconnect (either because they exit voluntarily or because
     // we disconnect them with `Worker#kill`), we'll receive the 'exit' event.
-    // Kill with the shutdown signal to respect signal exit codes: 
+    // Kill with the shutdown signal to respect signal exit codes:
     // https://nodejs.org/api/process.html#process_exit_codes
     setTimeout(forceKill, opts.grace).unref();
     process.on('exit', () => process.kill(process.pid, signal));

--- a/lib/throng.js
+++ b/lib/throng.js
@@ -38,9 +38,10 @@ module.exports = function throng(options, startFunction) {
   function listen() {
     cluster.on('exit', revive);
     emitter.once('shutdown', shutdown);
-    process
-      .on('SIGINT', proxySignal)
-      .on('SIGTERM', proxySignal);
+    var shutdownSignals = ['SIGINT', 'SIGTERM'];
+    shutdownSignals.forEach((signal) => {
+      process.once(signal, () => emitter.emit('shutdown', signal));
+    });
   }
 
   function fork() {
@@ -49,16 +50,20 @@ module.exports = function throng(options, startFunction) {
     }
   }
 
-  function proxySignal() {
-    emitter.emit('shutdown');
-  }
-
-  function shutdown() {
+  function shutdown(signal) {
     running = false;
     for (var id in cluster.workers) {
       cluster.workers[id].process.kill();
     }
+
+    // Unref'ing the timer ensures that the only thing keeping the master alive
+    // (as far as this module knows) are the connections to the child processes.
+    // When they disconnect (either because they exit voluntarily or because
+    // we disconnect them with `Worker#kill`), we'll receive the 'exit' event.
+    // Kill with the shutdown signal to respect signal exit codes: 
+    // https://nodejs.org/api/process.html#process_exit_codes
     setTimeout(forceKill, opts.grace).unref();
+    process.on('exit', () => process.kill(process.pid, signal));
   }
 
   function revive(worker, code, signal) {

--- a/lib/throng.js
+++ b/lib/throng.js
@@ -53,6 +53,7 @@ module.exports = function throng(options, startFunction) {
 
   function shutdown(signal) {
     running = false;
+    module.exports.shutdownSignal = signal;
     for (var id in cluster.workers) {
       cluster.workers[id].process.kill();
     }
@@ -75,6 +76,5 @@ module.exports = function throng(options, startFunction) {
     for (var id in cluster.workers) {
       cluster.workers[id].kill();
     }
-    process.exit();
   }
 };

--- a/lib/throng.js
+++ b/lib/throng.js
@@ -58,6 +58,7 @@ module.exports = function throng(options, startFunction) {
   function shutdown(signal) {
     running = false;
     module.exports.shutdownSignal = signal;
+    externEmitter.shutdownSignal = signal;
     for (const id in cluster.workers) {
       cluster.workers[id].process.kill();
     }

--- a/lib/throng.js
+++ b/lib/throng.js
@@ -40,8 +40,8 @@ module.exports = function throng(options, startFunction) {
 
   function listen() {
     cluster.on('disconnect', revive);
-    cluster.on('disconnect', (worker) => externEmitter.emit('disconnect', worker.pid));
-    cluster.on('exit', (worker) => externEmitter.emit('exit', worker.pid));
+    cluster.on('disconnect', (worker) => externEmitter.emit('disconnect', worker.id));
+    cluster.on('exit', (worker) => externEmitter.emit('exit', worker.id));
     const shutdownSignals = ['SIGINT', 'SIGTERM'];
     if (opts.extraShutdownSignal) shutdownSignals.push(opts.extraShutdownSignal);
     shutdownSignals.forEach((signal) => {

--- a/lib/throng.js
+++ b/lib/throng.js
@@ -21,14 +21,15 @@ module.exports = function throng(options, startFunction) {
   if (typeof startFn !== 'function') {
     throw new Error('Start function required');
   }
+  const externEmitter = new EventEmitter();
   if (cluster.isWorker) {
-    return startFn(cluster.worker.id);
+    startFn(cluster.worker.id);
+    // Return the noop emitter for a consistent API.
+    return externEmitter;
   }
 
   const opts = isNaN(options) ?
     defaults(options, DEFAULT_OPTIONS) : defaults({ workers: options }, DEFAULT_OPTIONS);
-  const emitter = new EventEmitter();
-  const externEmitter = new EventEmitter();
   const runUntil = Date.now() + opts.lifetime;
 
   let running = true;
@@ -41,11 +42,10 @@ module.exports = function throng(options, startFunction) {
     cluster.on('disconnect', revive);
     cluster.on('disconnect', (worker) => externEmitter.emit('disconnect', worker.pid));
     cluster.on('exit', (worker) => externEmitter.emit('exit', worker.pid));
-    emitter.once('shutdown', shutdown);
     const shutdownSignals = ['SIGINT', 'SIGTERM'];
     if (opts.extraShutdownSignal) shutdownSignals.push(opts.extraShutdownSignal);
     shutdownSignals.forEach((signal) => {
-      process.once(signal, () => emitter.emit('shutdown', signal));
+      process.once(signal, () => shutdown(signal));
     });
   }
 

--- a/lib/throng.js
+++ b/lib/throng.js
@@ -2,7 +2,7 @@
 
 const cluster = require('cluster');
 const EventEmitter = require('events').EventEmitter;
-const defaults = require('lodash.defaults');
+const defaults = require('lodash/defaults');
 const cpuCount = require('os').cpus().length;
 
 const DEFAULT_OPTIONS = {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,6 @@
     "mocha": "^2.4.5"
   },
   "dependencies": {
-    "lodash.defaults": "^4.0.1"
+    "lodash": "^4.17.10"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mixmaxhq/throng",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "description": "A simple worker-manager for clustered apps",
   "keywords": [
     "cluster",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mixmaxhq/throng",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "A simple worker-manager for clustered apps",
   "keywords": [
     "cluster",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "author": "Hunter Loftis <hunter@hunterloftis.com>",
   "license": "MIT",
   "devDependencies": {
-    "chai": "^3.5.0",
+    "chai": "^4.2.0",
     "mocha": "^6.1.4"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "license": "MIT",
   "devDependencies": {
     "chai": "^3.5.0",
-    "mocha": "^2.4.5"
+    "mocha": "^6.1.4"
   },
   "dependencies": {
     "lodash": "^4.17.10"

--- a/package.json
+++ b/package.json
@@ -1,15 +1,15 @@
 {
-  "name": "throng",
-  "version": "4.0.0",
+  "name": "@mixmaxhq/throng",
+  "version": "5.0.0",
   "description": "A simple worker-manager for clustered apps",
   "keywords": [
     "cluster",
     "worker",
     "process"
   ],
-  "repository": "hunterloftis/throng",
-  "homepage": "https://github.com/hunterloftis/throng",
-  "bugs": "https://github.com/hunterloftis/throng/issues",
+  "repository": "mixmaxhq/throng",
+  "homepage": "https://github.com/mixmaxhq/throng",
+  "bugs": "https://github.com/mixmaxhq/throng/issues",
   "main": "lib/throng.js",
   "files": [
     "lib"

--- a/readme.md
+++ b/readme.md
@@ -92,6 +92,14 @@ throng({
 // This will only be called once
 function startMaster() {
   console.log('Started master');
+
+  process.on('beforeExit', () => {
+    // `throng.shutdownSignal` will be `undefined` if the cluster exited without
+    // being killed e.g. if the workers exited by themselves and `lifetime` is 0.
+    console.log(`Master exiting in response to ${throng.shutdownSignal}...`);
+    // Making async calls will keep the master alive.
+    console.log('(master cleanup would happen here)');
+  });
 }
 
 // This will be called four times
@@ -116,6 +124,8 @@ Started worker 4
 
 $ killall node
 
+Master exiting in response to SIGTERM...
+(master cleanup would happen here)
 Worker 3 exiting...
 Worker 4 exiting...
 (cleanup would happen here)

--- a/readme.md
+++ b/readme.md
@@ -68,11 +68,13 @@ Handling signals (for cleanup on a kill signal, for instance).
 
 ```js
 throng({
-  workers: 4,       // Number of workers (cpu count)
-  lifetime: 10000,  // ms to keep cluster alive (Infinity)
-  grace: 4000,      // ms grace period after worker SIGTERM (5000)
-  master: masterFn, // Function to call when starting the master process
-  start: startFn    // Function to call when starting the worker processes
+  workers: 4,                     // Number of workers (cpu count)
+  lifetime: 10000,                // ms to keep cluster alive (Infinity)
+  grace: 4000,                    // ms grace period after worker SIGTERM (5000)
+  master: masterFn,               // Function to call when starting the master process
+  start: startFn,                 // Function to call when starting the worker processes
+  extraShutdownSignal: 'SIGUSR2'  // Extra signal (beyond SIGINT & SIGTERM) in response
+                                  // to which to shut down the cluster
 });
 ```
 

--- a/test/fixtures/beforeExit-graceful.js
+++ b/test/fixtures/beforeExit-graceful.js
@@ -1,0 +1,22 @@
+'use strict';
+
+const throng = require('../../lib/throng');
+
+throng({
+  workers: 2,
+  master: () => {
+    console.log('master');
+    
+    process.on('beforeExit', () => {
+      console.log(`Master exiting in response to ${throng.shutdownSignal}...`);
+    });
+  },
+  start: () => {
+    console.log('worker');
+    
+    process.on('SIGTERM', function() {
+      console.log('exiting');
+      process.exit();
+    });
+  }
+});

--- a/test/fixtures/beforeExit-kill.js
+++ b/test/fixtures/beforeExit-kill.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const throng = require('../../lib/throng');
+
+throng({
+  lifetime: 0,
+  workers: 2,
+  grace: 250,
+  master: () => {
+    console.log('master');
+    
+    process.on('beforeExit', () => {
+      console.log(`Master exiting in response to ${throng.shutdownSignal}...`);
+    });
+  },
+  start: () => {
+    console.log('ah ha ha ha');
+
+    process.on('SIGTERM', function() {
+      console.log('stayin alive');
+    });
+  }
+});

--- a/test/fixtures/beforeExit.js
+++ b/test/fixtures/beforeExit.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const throng = require('../../lib/throng');
+
+throng({
+  lifetime: 0,
+  workers: 2,
+  master: () => {
+    console.log('master');
+
+    process.on('beforeExit', () => {
+      console.log(`Master exiting in response to ${throng.shutdownSignal}...`);
+    });
+  },
+  start: () => {
+    console.log('worker');
+    process.exit();
+  }
+});

--- a/test/fixtures/sigusr2.js
+++ b/test/fixtures/sigusr2.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const throng = require('../../lib/throng');
+
+throng({
+  workers: 3,
+  lifetime: 500,
+  start: () => {
+    console.log('worker');
+
+    process.on('SIGTERM', function() {
+      console.log('exiting');
+      process.exit();
+    });
+  },
+  extraShutdownSignal: 'SIGUSR2'
+});

--- a/test/throng.test.js
+++ b/test/throng.test.js
@@ -16,6 +16,9 @@ const gracefulCmd = path.join(__dirname, 'fixtures', 'graceful');
 const killCmd = path.join(__dirname, 'fixtures', 'kill');
 const infiniteCmd = path.join(__dirname, 'fixtures', 'infinite');
 const sigusr2Cmd = path.join(__dirname, 'fixtures', 'sigusr2');
+const beforeExitCmd = path.join(__dirname, 'fixtures', 'beforeExit');
+const beforeExitGracefulCmd = path.join(__dirname, 'fixtures', 'beforeExit-graceful');
+const beforeExitKillCmd = path.join(__dirname, 'fixtures', 'beforeExit-kill');
 
 describe('throng()', function() {
 
@@ -190,6 +193,38 @@ describe('throng()', function() {
 
   });
 
+  describe('`beforeExit` handler', function() {
+
+    describe('with 3 workers that immediately exit', function() {
+      before(function(done) {
+        run(beforeExitCmd, this, done);
+      });
+      it('the `beforeExit` handler is invoked', function() {
+        assert.notEqual(this.stdout.indexOf('Master exiting in response to undefined'), -1);
+      });
+    });
+
+    describe('with 3 workers that exit gracefully', function() {
+      before(function(done) {
+        var child = run(beforeExitGracefulCmd, this, done);
+        setTimeout(function() { child.kill(); }, 750);
+      });
+      it('the `beforeExit` handler is invoked', function() {
+        assert.notEqual(this.stdout.indexOf('Master exiting in response to SIGTERM'), -1);
+      });
+    });
+
+    describe('with 3 workers that fail to exit', function() {
+      before(function(done) {
+        var child = run(beforeExitKillCmd, this, done);
+        setTimeout(function() { child.kill(); }, 750);
+      });
+      it('the `beforeExit` handler is invoked', function() {
+        assert.notEqual(this.stdout.indexOf('Master exiting in response to SIGTERM'), -1);
+      });
+    });
+
+  });
 });
 
 function run(file, context, done) {

--- a/test/throng.test.js
+++ b/test/throng.test.js
@@ -15,6 +15,7 @@ const masterCmd = path.join(__dirname, 'fixtures', 'master');
 const gracefulCmd = path.join(__dirname, 'fixtures', 'graceful');
 const killCmd = path.join(__dirname, 'fixtures', 'kill');
 const infiniteCmd = path.join(__dirname, 'fixtures', 'infinite');
+const sigusr2Cmd = path.join(__dirname, 'fixtures', 'sigusr2');
 
 describe('throng()', function() {
 
@@ -170,6 +171,20 @@ describe('throng()', function() {
       });
       it('exits with SIGINT', function() {
         assert.equal(this.signal, 'SIGINT');
+      });
+    });
+
+    describe('with custom signal handling', function() {
+      before(function(done) {
+        var child = run(sigusr2Cmd, this, done);
+        setTimeout(function() { child.kill('SIGUSR2'); }, 750);
+      });
+      it('allows the workers to shut down', function() {
+        var exits = this.stdout.match(/exiting/g).length;
+        assert.equal(exits, 3);
+      });
+      it('exits with SIGUSR2', function() {
+        assert.equal(this.signal, 'SIGUSR2');
       });
     });
 


### PR DESCRIPTION
This PR allows `throng` users to take advantage of the `env` parameter accepted by [cluster.fork](https://nodejs.org/docs/latest-v10.x/api/cluster.html#cluster_cluster_fork_env)