### PR TITLE
remove un-necessary dependency on lodash

### DIFF
--- a/lib/throng.js
+++ b/lib/throng.js
@@ -1,6 +1,5 @@
 const cluster = require('cluster')
 const os = require('os')
-const defaultsDeep = require('lodash').defaultsDeep
 
 const nCPU = os.cpus().length
 const defaults = {
@@ -12,7 +11,7 @@ const defaults = {
 }
 
 module.exports = async function throng(options, legacy) {
-  const config = defaultsDeep({}, parseOptions(options, legacy), defaults)
+  const config = Object.assign({}, defaults, parseOptions(options, legacy))
   const worker = config.worker
   const master = config.master
 
@@ -26,7 +25,7 @@ module.exports = async function throng(options, legacy) {
 
   const reviveUntil = Date.now() + config.lifetime
   let running = true
-  
+
   listen()
   await master()
   fork(config.count)
@@ -40,7 +39,7 @@ module.exports = async function throng(options, legacy) {
     return () => {
       running = false
       setTimeout(() => forceKill(signal), config.grace).unref()
-      
+
       Object.values(cluster.workers).forEach(w => {
         w.process.kill(signal)
       })

--- a/package-lock.json
+++ b/package-lock.json
@@ -606,11 +606,6 @@
         "p-locate": "^5.0.0"
       }
     },
-    "lodash": {
-      "version": "4.17.20",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
-    },
     "log-symbols": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,5 @@
     "mocha": "^8.1.3"
   },
   "dependencies": {
-    "lodash": "^4.17.20"
   }
 }


### PR DESCRIPTION
This fixes incoherent behaviors introduced by deepMerge. If only one signal is provided, the default second one is still present.

```js
> defaultsDeep({}, { signals:['SIGSTOP'] }, defaults)

{
  signals: [ 'SIGSTOP', 'SIGINT' ],
  master: [Function: master],
  count: 8,
  lifetime: Infinity,
  grace: 5000
}

> defaultsDeep({}, { signals:['SIGINT'] }, defaults)
{
  signals: [ 'SIGINT', 'SIGINT' ],
  master: [Function: master],
  count: 8,
  lifetime: Infinity,
  grace: 5000
}
```

There is no added benefit of using lodash here.