### PR TITLE
Track worker deaths and revive exactly once on disconnect or exit.

### DIFF
--- a/examples/crashy-oom.js
+++ b/examples/crashy-oom.js
@@ -1,0 +1,16 @@
+const throng = require('../lib/throng')
+
+throng({ worker, count: 3 })
+
+function worker(id) {
+    setInterval(() => process.stdout.write(`-${id}-`), 1000)
+    setTimeout(() => { 
+        // Trigger OOM...this *can* crash without emitting `disconnect`
+        process.stdout.write('-OOMing!-')
+
+        const arrays = [];
+        while (true) {
+            arrays.push(new Array(100000));    
+        }
+    }, Math.random() * 5000 + 5000)
+}

--- a/examples/crashy.js
+++ b/examples/crashy.js
@@ -6,6 +6,11 @@ function worker(id) {
     setInterval(() => process.stdout.write(`-${id}-`), 1000)
     setTimeout(() => { 
         process.stdout.write('-crash!-')
+        // Different ways to crash the process...all will emit `disconnect`
+        // throw new Error()
+        // Promise.reject()
+        // process.emit('error')
+        // process.kill(process.pid, "SIGTERM")
         process.exit()
     }, Math.random() * 5000 + 5000)
 }

--- a/lib/throng.js
+++ b/lib/throng.js
@@ -33,6 +33,7 @@ module.exports = async function throng(options, legacy) {
 
   function listen() {
     cluster.on('disconnect', revive)
+    cluster.on('exit', revive)
     config.signals.forEach(signal => process.on(signal, shutdown(signal)))
   }
 
@@ -47,10 +48,17 @@ module.exports = async function throng(options, legacy) {
     }
   }
 
-  function revive() {
+  // We cannot rely on every exited worker sending `disconnect`,
+  // so listen to both `disconnect` and `exit` and track deaths
+  // to avoid duplicate calls to revive().
+  const deaths = []
+  function revive(worker) {
     if (!running) return
     if (Date.now() >= reviveUntil) return
-    cluster.fork()
+    if (!deaths.includes(worker.id)) {
+      deaths.push(worker.id);
+      cluster.fork()
+    }
   }
 
   function forceKill(signal) {


### PR DESCRIPTION
We recently upgraded to `throng v5` in production and have noticed that sometimes crashed workers are not restarted. This is due to the [change](https://github.com/hunterloftis/throng/commit/c595d1a103ab6824c7cebec87d668e26e8e53dcc) from using `exit` to `disconnect` to trigger revival. 

Unfortunately when a NodeJS worker process is killed due to OOM, sometimes it does not emit `disconnect` to the master process. In this case, only an `exit` will be received. This PR retains the revive-on-disconnect behavior of v5.0, but adds a fallback to handle `exit`-only crashes.